### PR TITLE
Add rendered images to static_files

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ Add the following to your `Gemfile`:
 gem 'jekyll-thumbnail-img'
 ```
 
+And then add the plugin to your `_config.yml`:
+```
+plugins:
+  - jekyll-thumbnail-img
+```
+
 # Usage
 The plugin provides a Liquid filter `thumbnail_img` as follows:
 ```

--- a/lib/jekyll-thumbnail-img.rb
+++ b/lib/jekyll-thumbnail-img.rb
@@ -1,50 +1,58 @@
-require "jekyll"
-require "mini_magick"
+require 'jekyll'
+require 'mini_magick'
 
-class JekyllThumbnailImg < Liquid::Tag
-  def initialize(tag_name, markup, tokens)
-    super
-    @markup = markup
-  end
-
-  def render(context)
-    source, width = @markup.split(" ").map(&:strip)
-
-    # Check if the source is a Liquid variable and attempt to resolve it
-    if context[source]
-      source = context[source]
-    end
-    unless source && width
-      raise "Usage: {% thumbnail_img /path/to/local/image.png 500 %}"
+module Jekyll
+  class JekyllThumbnailImg < Liquid::Tag
+    def initialize(tag_name, markup, tokens)
+      super
+      @markup = markup
     end
 
-    source_path = File.join(context.registers[:site].source, source)
+    def render(context)
+      source, width = @markup.split(" ").map(&:strip)
 
-    # Check if the source file exists
-    unless File.exist?(source_path)
-      raise "File #{source} could not be found"
+      # Check if the source is a Liquid variable and attempt to resolve it
+      if context[source]
+        source = context[source]
+      end
+      unless source && width
+        raise "Usage: {% thumbnail_img /path/to/local/image.png 500 %}"
+      end
+
+      source_path = File.join(context.registers[:site].source, source)
+
+      # Check if the source file exists
+      unless File.exist?(source_path)
+        raise "File #{source} could not be found"
+      end
+
+      # Calculate the relative path to the 'thumbnails' directory
+      relative_dest_dir = File.join(File.dirname(source), "thumbnails")
+
+      # Create the 'thumbnails' directory within the source directory
+      dest_dir = File.join(context.registers[:site].source, relative_dest_dir)
+      Dir.mkdir(dest_dir) unless Dir.exist?(dest_dir)
+
+      ext = File.extname(source)
+      dest = File.join(relative_dest_dir, File.basename(source, ext) + "_#{width}w#{ext}")
+
+      # Generate the thumbnail if it doesn't exist or if the source file was modified more recently than the thumbnail
+      full_dest_path = File.join(context.registers[:site].source, dest)
+      if !File.exist?(full_dest_path) || File.mtime(full_dest_path) <= File.mtime(source_path)
+        image = MiniMagick::Image.open(source_path)
+        image.resize("#{width}x")
+        image.write(full_dest_path)
+        Jekyll.logger.info "JekyllThumbnailImg", "Generating: " + File.join(context.registers[:site].source, dest)
+        context["site"]["static_files"] << StaticFile.new(
+          context.registers[:site],
+          context.registers[:site].source,
+          @dir,
+          dest
+        )
+      end
+      dest
     end
-
-    # Calculate the relative path to the 'thumbnails' directory
-    relative_dest_dir = File.join(File.dirname(source), "thumbnails")
-
-    # Create the 'thumbnails' directory within the source directory
-    dest_dir = File.join(context.registers[:site].source, relative_dest_dir)
-    Dir.mkdir(dest_dir) unless Dir.exist?(dest_dir)
-
-    ext = File.extname(source)
-    dest = File.join(relative_dest_dir, File.basename(source, ext) + "_#{width}w#{ext}")
-
-    # Generate the thumbnail if it doesn't exist or if the source file was modified more recently than the thumbnail
-    full_dest_path = File.join(context.registers[:site].source, dest)
-    if !File.exist?(full_dest_path) || File.mtime(full_dest_path) <= File.mtime(source_path)
-      image = MiniMagick::Image.open(source_path)
-      image.resize("#{width}x")
-      image.write(File.join(context.registers[:site].source, dest))
-    end
-
-    dest
   end
 end
 
-Liquid::Template.register_tag("thumbnail_img", JekyllThumbnailImg)
+Liquid::Template.register_tag("thumbnail_img", Jekyll::JekyllThumbnailImg)


### PR DESCRIPTION
so they are copied to _site/assets later

Sorry for the bad diff. The only thing I tried to do is:
- Add a module around it
- add some logging
- And the most important: add the generated files to context["site"]["static_files"] in line 46

Fixes #2

If you ignore whitespace changes it is a lot better to see:
https://github.com/abpaudel/jekyll-thumbnail-img/pull/3/files?diff=unified&w=1