### PR TITLE
Cache thumbnails to avoid regeneration + allow getting the width from a variable

### DIFF
--- a/lib/jekyll-thumbnail-img.rb
+++ b/lib/jekyll-thumbnail-img.rb
@@ -12,7 +12,9 @@ module Jekyll
 
     def render(context)
       source, width = @markup.split.map(&:strip)
-      source = context[source] if context[source]  # resolve liquid vars
+      # resolve liquid vars
+      source = context[source] if context[source]
+      width = context[width] if context[width]
 
       raise "Usage: {% thumbnail_img /path/to/image.png 500 %}" unless source && width
       raise "File #{source} not found" unless File.exist?(File.join(context.registers[:site].source, source))

--- a/lib/jekyll-thumbnail-img.rb
+++ b/lib/jekyll-thumbnail-img.rb
@@ -17,13 +17,20 @@ module Jekyll
       width = context[width] if context[width]
 
       raise "Usage: {% thumbnail_img /path/to/image.png 500 %}" unless source && width
-      raise "File #{source} not found" unless File.exist?(File.join(context.registers[:site].source, source))
+
+      site = context.registers[:site]
+      raise "File #{source} not found" unless File.exist?(File.join(site.source, source))
 
       # Queue thumbnail for generation
-      dest = File.join(File.dirname(source), "thumbnails", "#{File.basename(source, '.*')}_#{width}w#{File.extname(source)}")
+      thumb_filename = "#{File.basename(source, '.*')}_#{width}w#{File.extname(source)}"
+      thumb_dir = File.join('.thumbnails', File.dirname(source), 'thumbnails')
+      dest = File.join(File.dirname(source), "thumbnails", thumb_filename)
+
+      # Add to pending list if not already there
       @@pending << {
-        source: File.join(context.registers[:site].source, source),
-        dest: File.join(context.registers[:site].dest, dest),
+        source: File.join(site.source, source),
+        cache: File.join(site.source, thumb_dir, thumb_filename),
+        dest: File.join(site.dest, dest),
         width: width
       } unless @@pending.any? { |thumb| thumb[:source] == source && thumb[:width] == width }
 
@@ -32,11 +39,17 @@ module Jekyll
 
     def self.generate_thumbnails(site)
       @@pending.each do |thumb|
+        FileUtils.mkdir_p(File.dirname(thumb[:cache]))
         FileUtils.mkdir_p(File.dirname(thumb[:dest]))
-        if !File.exist?(thumb[:dest]) || File.mtime(thumb[:dest]) <= File.mtime(thumb[:source])
+
+        # Generate thumbnail if not already generated or source is newer
+        if !File.exist?(thumb[:cache]) || File.mtime(thumb[:cache]) <= File.mtime(thumb[:source])
           Jekyll.logger.info "JekyllThumbnailImg:", "Generating: #{thumb[:dest].sub(site.dest + '/', '')}"
-          MiniMagick::Image.open(thumb[:source]).resize("#{thumb[:width]}x").write(thumb[:dest])
+          MiniMagick::Image.open(thumb[:source]).resize("#{thumb[:width]}x").write(thumb[:cache])
         end
+
+        # Copy from cache to destination
+        FileUtils.cp(thumb[:cache], thumb[:dest])
       end
       @@pending.clear
     end

--- a/lib/jekyll-thumbnail-img.rb
+++ b/lib/jekyll-thumbnail-img.rb
@@ -23,13 +23,13 @@ module Jekyll
 
       # Queue thumbnail for generation
       thumb_filename = "#{File.basename(source, '.*')}_#{width}w#{File.extname(source)}"
-      thumb_dir = File.join('.thumbnails', File.dirname(source), 'thumbnails')
+      cache_dir = File.join(site.config["cache_dir"], "jekyll-thumbnail-img/img-cache", File.dirname(source), "thumbnails")
       dest = File.join(File.dirname(source), "thumbnails", thumb_filename)
 
       # Add to pending list if not already there
       @@pending << {
         source: File.join(site.source, source),
-        cache: File.join(site.source, thumb_dir, thumb_filename),
+        cache: File.join(cache_dir, thumb_filename),
         dest: File.join(site.dest, dest),
         width: width
       } unless @@pending.any? { |thumb| thumb[:source] == source && thumb[:width] == width }

--- a/lib/jekyll-thumbnail-img.rb
+++ b/lib/jekyll-thumbnail-img.rb
@@ -25,7 +25,7 @@ module Jekyll
         source: File.join(context.registers[:site].source, source),
         dest: File.join(context.registers[:site].dest, dest),
         width: width
-      }
+      } unless @@pending.any? { |thumb| thumb[:source] == source && thumb[:width] == width }
 
       dest
     end


### PR DESCRIPTION
Hi, this PR includes the changes from #4 (which I already closed) to allow setting the width using a variable (whether assigned in the template or from the Front Matter), and extends it with a new feature: generating the thumbnails in a directory within Jekyll's built-in cache and copying them to the appropriate destination as needed in order to avoid having to generate all thumbnails again every time any file changes in the Jekyll site. That latter problem was driving me insane as I had to wait over a minute for the site to regenerate every time I changed anything, and other users wanted this feature as well (see issue #5).

Again, thanks to @abpaudel for creating this plugin, hope you approve this PR soon.

**Commits:**
- **Try to resolve width from context vars as well**
- **Add condition to avoid duplicate items in pending list**
- **Generate thumbnails in cache directory to avoid needless regeneration**
- **Use Jekyll's built-in cache dir to avoid having to do extra config**
